### PR TITLE
Use ssh for submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "git-test"]
 	path = git-test
-	url = git@github.com:ansistrano/git-test.git
+	url = https://github.com/ansistrano/git-test.git


### PR DESCRIPTION
Using git protocol (rather than ssl) for submodule's url prevents anyone without write access from cloning it -- and thus from running tests

See: https://gist.github.com/EvanK/7295fa96cffb151fd770a20ad11fcc89